### PR TITLE
otf2bfd.c: fix exit code when generate_font is run

### DIFF
--- a/otf2bdf.c
+++ b/otf2bdf.c
@@ -1102,8 +1102,11 @@ generate_font(FILE *out, char *iname, char *oname)
      * End the font and do memory cleanup on the glyph and raster structures.
      */
     eof = fprintf(out, "ENDFONT\n");
+    if (eof < 0) {
+       return eof;
+    }
 
-    return eof;
+    return 0;
 }
 
 static int


### PR DESCRIPTION
The generate_font() function uses the result of fprintf() as its
return value. This is the number of chars written or a negative
number in case of an error. The otfbdf.c code uses that return
code as the exit-code of the entire program. This will break
scripts that use "set -e" because a successful run of otf2bdf
will result in an exit-code of 8 (`fprintf(out, "ENDFONT\n");`
is the last write).

This patch changes the return code of generate_font() to 0
in case there is no error and to -1 if there is an error.

This will lead to an exit-code of zero if generate_font()
was successful.