### PR TITLE
comment regard bbx y offset calculation

### DIFF
--- a/otf2bdf.c
+++ b/otf2bdf.c
@@ -877,7 +877,7 @@ generate_font(FILE *out, char *iname, char *oname)
         wd = ex - sx;
         ht = ey - sy;
         x_off = sx + face->glyph->bitmap_left;
-        y_off = sy + face->glyph->bitmap_top - face->glyph->bitmap.rows;
+        y_off = sy + face->glyph->bitmap_top - face->glyph->bitmap.rows; // this might be wrong and should be: y_off = face->glyph->bitmap_top - ey;  // see https://github.com/olikraus/u8g2/issues/2406
 
         bbx.maxas = MAX(bbx.maxas, ht + y_off);
         bbx.maxds = MAX(bbx.maxds, -y_off);


### PR DESCRIPTION
Thanks for hosting a copy of otf2bdf.

Unfortunately issues and discussions are off for this project, so I created a PR with a single comment:
I think there is a bug in  the calculation of the y offset of the BBX value.
See here: https://github.com/olikraus/u8g2/issues/2406

Still I can't confirm that the fix would work, but at least for that specific font (see above linked issue) the problem is solved.

Anyhow, it is just a comment and the PR has no impact on the code itself.
